### PR TITLE
Feat/oauth login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/nighttrip/core/domain/user/entity/User.java
+++ b/src/main/java/com/nighttrip/core/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.nighttrip.core.domain.user.entity;
 
 import com.nighttrip.core.domain.avatar.entity.Avatar;
 import com.nighttrip.core.domain.tripplan.entity.TripPlan;
+import com.nighttrip.core.global.enums.Oauth_Provider;
 import com.nighttrip.core.global.enums.User_role;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -29,8 +30,9 @@ public class User {
     @Column(length = 100)
     private String nickname;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private String provider;
+    private Oauth_Provider provider;
 
     @Column(name = "social_id", nullable = false)
     private String socialId;
@@ -48,4 +50,11 @@ public class User {
 
     @OneToMany(mappedBy = "user")
     private List<TripPlan> tripPlans = new ArrayList<>();
+
+    public User(String email, String nickname, String socialId, Oauth_Provider provider) {
+        this.email = email;
+        this.nickname = nickname;
+        this.socialId = socialId;
+        this.provider = provider;
+    }
 }

--- a/src/main/java/com/nighttrip/core/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/nighttrip/core/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.nighttrip.core.domain.user.repository;
+
+import com.nighttrip.core.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/nighttrip/core/global/config/SecurityConfig.java
+++ b/src/main/java/com/nighttrip/core/global/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.nighttrip.core.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/oauth/**",
+                                "/login/oauth2/**",
+                                "/oauth2/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/nighttrip/core/global/config/WebClientConfig.java
+++ b/src/main/java/com/nighttrip/core/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.nighttrip.core.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/nighttrip/core/global/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/nighttrip/core/global/controller/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.nighttrip.core.global.controller;
+
+import com.nighttrip.core.global.dto.ApiErrorResponse;
+import com.nighttrip.core.global.exception.BusinessException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiErrorResponse> handleBusinessException(BusinessException ex) {
+        return ResponseEntity.status(ex.getStatus())
+                .body(ApiErrorResponse.of(
+                        ex.getStatus().name(),
+                        ex.getMessage()
+                ));
+    }
+}

--- a/src/main/java/com/nighttrip/core/global/dto/ApiErrorResponse.java
+++ b/src/main/java/com/nighttrip/core/global/dto/ApiErrorResponse.java
@@ -1,0 +1,16 @@
+package com.nighttrip.core.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record ApiErrorResponse(
+        String error,
+        String message,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime timestamp
+) {
+    public static ApiErrorResponse of(String error, String message) {
+        return new ApiErrorResponse(error, message, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/nighttrip/core/global/dto/ApiResponse.java
+++ b/src/main/java/com/nighttrip/core/global/dto/ApiResponse.java
@@ -1,0 +1,14 @@
+package com.nighttrip.core.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record ApiResponse<T>(String message , T data,
+                             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+                             LocalDateTime timestamp) {
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("success", data, LocalDateTime.now());
+    }
+
+}

--- a/src/main/java/com/nighttrip/core/global/enums/ErrorCode.java
+++ b/src/main/java/com/nighttrip/core/global/enums/ErrorCode.java
@@ -8,7 +8,14 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 유저입니다."),
-	PLACE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 장소입니다.");
+	PLACE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 장소입니다."),
+
+	INVALID_OAUTH_CODE_MISSING(HttpStatus.BAD_REQUEST, "인가 코드가 누락되었습니다."),
+	INVALID_OAUTH_CODE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 인가 코드입니다."),
+	UNSUPPORTED_SOCIAL_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인입니다."),
+	EMAIL_ALREADY_REGISTERED(HttpStatus.CONFLICT, "해당 이메일은 이미 다른 소셜 계정으로 가입되어 있습니다."),
+	OAUTH_PROVIDER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OAuth 공급자에서 에러가 발생했습니다.");
+
 	private final HttpStatus errorCode;
 	private final String message;
 

--- a/src/main/java/com/nighttrip/core/global/enums/Oauth_Provider.java
+++ b/src/main/java/com/nighttrip/core/global/enums/Oauth_Provider.java
@@ -1,5 +1,5 @@
 package com.nighttrip.core.global.enums;
 
 public enum Oauth_Provider {
-    KAKAO,GOOGLE;
+    KAKAO,GOOGLE,NAVER;
 }

--- a/src/main/java/com/nighttrip/core/global/exception/BusinessException.java
+++ b/src/main/java/com/nighttrip/core/global/exception/BusinessException.java
@@ -1,5 +1,6 @@
 package com.nighttrip.core.global.exception;
 
+import com.nighttrip.core.global.enums.ErrorCode;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -10,5 +11,10 @@ public class BusinessException extends RuntimeException {
 	public BusinessException(HttpStatus status, String message) {
 		super(message);
 		this.status = status;
+	}
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.status = errorCode.getErrorCode();
 	}
 }

--- a/src/main/java/com/nighttrip/core/oauth/controller/OAuthController.java
+++ b/src/main/java/com/nighttrip/core/oauth/controller/OAuthController.java
@@ -1,0 +1,82 @@
+package com.nighttrip.core.oauth.controller;
+
+import com.nighttrip.core.domain.user.entity.User;
+import com.nighttrip.core.domain.user.repository.UserRepository;
+import com.nighttrip.core.global.dto.ApiResponse;
+import com.nighttrip.core.global.enums.ErrorCode;
+import com.nighttrip.core.global.exception.BusinessException;
+import com.nighttrip.core.oauth.dto.LoginResponseDto;
+import com.nighttrip.core.oauth.dto.OAuthUserInfo;
+import com.nighttrip.core.oauth.service.GoogleOAuthService;
+import com.nighttrip.core.oauth.service.KakaoOAuthService;
+import com.nighttrip.core.oauth.service.NaverOAuthService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/oauth")
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final GoogleOAuthService googleOAuthService;
+    private final KakaoOAuthService kakaoOAuthService;
+    private final NaverOAuthService naverOAuthService;
+    private final UserRepository userRepository;
+    private final HttpSession httpSession;
+
+    @PostMapping(value = "/login/{provider}", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    public ResponseEntity<?> loginFormEncoded(@PathVariable String provider,
+                                              @RequestParam("code") String code) {
+        return handleLogin(provider, code);
+    }
+
+    @PostMapping(value = "/login/{provider}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> loginJson(@PathVariable String provider,
+                                       @RequestBody Map<String, String> body) {
+        String code = body.get("code");
+        return handleLogin(provider, code);
+    }
+
+    private ResponseEntity<?> handleLogin(String provider, String code) {
+        if (code == null || code.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_OAUTH_CODE_MISSING);
+        }
+
+        OAuthUserInfo userInfo = switch (provider.toUpperCase()) {
+            case "GOOGLE" -> googleOAuthService.getUserInfo(code);
+            case "KAKAO" -> kakaoOAuthService.getUserInfo(code);
+            case "NAVER" -> naverOAuthService.getUserInfo(code);
+            default -> throw new BusinessException(ErrorCode.UNSUPPORTED_SOCIAL_PROVIDER);
+        };
+
+        Optional<User> optionalUser = userRepository.findByEmail(userInfo.getEmail());
+        User user = optionalUser.map(existingUser -> {
+            if (existingUser.getProvider() != userInfo.getProvider()) {
+                throw new BusinessException(ErrorCode.EMAIL_ALREADY_REGISTERED);
+            }
+            return existingUser;
+        }).orElseGet(() -> userRepository.save(new User(
+                userInfo.getEmail(),
+                userInfo.getNickname(),
+                userInfo.getSocialId(),
+                userInfo.getProvider()
+        )));
+
+
+
+        LoginResponseDto dto = new LoginResponseDto(user.getId(), user.getEmail(), user.getNickname());
+        return ResponseEntity.ok(ApiResponse.success(dto));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout() {
+        httpSession.invalidate();
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/nighttrip/core/oauth/dto/LoginResponseDto.java
+++ b/src/main/java/com/nighttrip/core/oauth/dto/LoginResponseDto.java
@@ -1,0 +1,7 @@
+package com.nighttrip.core.oauth.dto;
+
+public record LoginResponseDto(
+        Long userId,
+        String email,
+        String nickname
+) {}

--- a/src/main/java/com/nighttrip/core/oauth/dto/OAuthUserInfo.java
+++ b/src/main/java/com/nighttrip/core/oauth/dto/OAuthUserInfo.java
@@ -1,0 +1,14 @@
+package com.nighttrip.core.oauth.dto;
+
+import com.nighttrip.core.global.enums.Oauth_Provider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OAuthUserInfo {
+    private String email;
+    private String nickname;
+    private String socialId;
+    private Oauth_Provider provider;
+}

--- a/src/main/java/com/nighttrip/core/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/com/nighttrip/core/oauth/service/GoogleOAuthService.java
@@ -1,0 +1,84 @@
+package com.nighttrip.core.oauth.service;
+
+import com.nighttrip.core.global.enums.ErrorCode;
+import com.nighttrip.core.global.enums.Oauth_Provider;
+import com.nighttrip.core.global.exception.BusinessException;
+import com.nighttrip.core.oauth.dto.OAuthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuthService implements OAuthLoginService {
+
+    private final WebClient webClient;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public OAuthUserInfo getUserInfo(String code) {
+        String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+
+        String accessToken = webClient.post()
+                .uri("https://oauth2.googleapis.com/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData("code", decodedCode)
+                        .with("client_id", clientId)
+                        .with("client_secret", clientSecret)
+                        .with("redirect_uri", redirectUri)
+                        .with("grant_type", "authorization_code"))
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID)))
+                .onStatus(status -> status.is5xxServerError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)))
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .map(body -> {
+                    if (!body.containsKey("access_token")) {
+                        throw new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID);
+                    }
+                    return (String) body.get("access_token");
+                })
+                .block();
+
+        Map<String, Object> userInfo = webClient.get()
+                .uri("https://www.googleapis.com/oauth2/v2/userinfo")
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID)))
+                .onStatus(status -> status.is5xxServerError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)))
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+
+        if (userInfo == null || userInfo.get("id") == null) {
+            throw new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID);
+        }
+
+        return new OAuthUserInfo(
+                (String) userInfo.get("email"),
+                (String) userInfo.get("name"),
+                (String) userInfo.get("id"),
+                Oauth_Provider.GOOGLE
+        );
+    }
+}
+

--- a/src/main/java/com/nighttrip/core/oauth/service/KakaoOAuthService.java
+++ b/src/main/java/com/nighttrip/core/oauth/service/KakaoOAuthService.java
@@ -1,0 +1,85 @@
+package com.nighttrip.core.oauth.service;
+
+import com.nighttrip.core.global.enums.ErrorCode;
+import com.nighttrip.core.global.enums.Oauth_Provider;
+import com.nighttrip.core.global.exception.BusinessException;
+import com.nighttrip.core.oauth.dto.OAuthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService implements OAuthLoginService {
+
+    private final WebClient webClient;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public OAuthUserInfo getUserInfo(String code) {
+        String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+
+        String accessToken = webClient.post()
+                .uri("https://kauth.kakao.com/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                        .with("client_id", clientId)
+                        .with("redirect_uri", redirectUri)
+                        .with("code", decodedCode))
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID)))
+                .onStatus(status -> status.is5xxServerError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)))
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .map(body -> {
+                    if (!body.containsKey("access_token")) {
+                        throw new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID);
+                    }
+                    return (String) body.get("access_token");
+                })
+                .block();
+
+        Map<String, Object> userInfo = webClient.get()
+                .uri("https://kapi.kakao.com/v2/user/me")
+                .headers(headers -> {
+                    headers.setBearerAuth(accessToken);
+                    headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+                })
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID)))
+                .onStatus(status -> status.is5xxServerError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)))
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+
+        if (userInfo == null || userInfo.get("id") == null) {
+            throw new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID);
+        }
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) userInfo.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        return new OAuthUserInfo(
+                (String) kakaoAccount.get("email"),
+                (String) profile.get("nickname"),
+                userInfo.get("id").toString(),
+                Oauth_Provider.KAKAO
+        );
+    }
+}

--- a/src/main/java/com/nighttrip/core/oauth/service/NaverOAuthService.java
+++ b/src/main/java/com/nighttrip/core/oauth/service/NaverOAuthService.java
@@ -1,0 +1,87 @@
+package com.nighttrip.core.oauth.service;
+
+import com.nighttrip.core.global.enums.ErrorCode;
+import com.nighttrip.core.global.enums.Oauth_Provider;
+import com.nighttrip.core.global.exception.BusinessException;
+import com.nighttrip.core.oauth.dto.OAuthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NaverOAuthService implements OAuthLoginService {
+
+    private final WebClient webClient;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.naver.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public OAuthUserInfo getUserInfo(String code) {
+        String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+
+        String accessToken = webClient.post()
+                .uri("https://nid.naver.com/oauth2.0/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                        .with("client_id", clientId)
+                        .with("client_secret", clientSecret)
+                        .with("redirect_uri", redirectUri)
+                        .with("code", decodedCode))
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID)))
+                .onStatus(status -> status.is5xxServerError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)))
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .map(body -> {
+                    if (!body.containsKey("access_token")) {
+                        throw new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID);
+                    }
+                    return (String) body.get("access_token");
+                })
+                .block();
+
+        Map<String, Object> result = webClient.get()
+                .uri("https://openapi.naver.com/v1/nid/me")
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID)))
+                .onStatus(status -> status.is5xxServerError(),
+                        response -> Mono.error(new BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)))
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+
+        if (result == null || !"success".equals(result.get("message"))) {
+            throw new BusinessException(ErrorCode.INVALID_OAUTH_CODE_INVALID);
+        }
+
+        Map<String, Object> response = (Map<String, Object>) result.get("response");
+
+        return new OAuthUserInfo(
+                (String) response.get("email"),
+                (String) response.get("nickname"),
+                (String) response.get("id"),
+                Oauth_Provider.NAVER
+        );
+    }
+}
+
+

--- a/src/main/java/com/nighttrip/core/oauth/service/OAuthLoginService.java
+++ b/src/main/java/com/nighttrip/core/oauth/service/OAuthLoginService.java
@@ -1,0 +1,7 @@
+package com.nighttrip.core.oauth.service;
+
+import com.nighttrip.core.oauth.dto.OAuthUserInfo;
+
+public interface OAuthLoginService {
+    OAuthUserInfo getUserInfo(String code);
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,8 +4,8 @@ spring:
 
   datasource:
     url: jdbc:postgresql://localhost:5432/xcp
-    username: admin
-    password: "0000"
+    username: postgres
+    password: "1234"
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 10
@@ -20,3 +20,49 @@ spring:
       properties:
         hibernate:
           format_sql: true
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+            scope:
+              - profile
+              - email
+            client-name: Google
+            authorization-grant-type: authorization_code
+            provider: google
+
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            client-name: Kakao
+            authorization-grant-type: authorization_code
+            scope:
+              - profile
+              - account_email
+            provider: kakao
+
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: "http://localhost:8080/login/oauth2/code/naver"
+            client-name: Naver
+            authorization-grant-type: authorization_code
+            provider: naver
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 소셜 로그인 및 회원가입 기능 구현, 예외 및 응답 처리 통합

## 📝 요구 사항과 구현 내용
-OAuthUserInfo 도입으로 소셜 제공자별 사용자 정보 통합
-구글 소셜 로그인/회원가입 구현
-네이버 소셜 로그인/회원가입 구현
-카카오 소셜 로그인/회원가입 구현
-OAuthLoginService 인터페이스 생성 및 각 소셜 서비스 구현체에서 상속
-OAuthController에 로그인 처리 로직 구현
-응답 통일화: ApiResponse.success(data)로 응답
-예외 발생 시 BusinessException을 통해 GlobalExceptionHandler에서 처리
-에러 응답: ApiErrorResponse 사용

## 💬 PR 포인트 & 궁금한 점
- Repository secrets 추가: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, KAKAO_CLIENT_ID, NAVER_CLIENT_ID, NAVER_CLIENT_SECRET

## 🔗 연관된 이슈
- close #2  [Feat] 소셜 로그인/회원가입 기능 구현