### PR TITLE
feat: 로그인 상태 확인 API 구현

### DIFF
--- a/src/main/java/com/nighttrip/core/domain/city/entity/City.java
+++ b/src/main/java/com/nighttrip/core/domain/city/entity/City.java
@@ -35,7 +35,7 @@ public class City {
 
     private String sigunguCode;
     private Integer visitedNumber;
-    private Integer chkeCount;
+    private Integer checkCount;
 
     @Column(name = "city_image_url")
     private String imageUrl;

--- a/src/main/java/com/nighttrip/core/domain/touristspot/entity/TouristSpot.java
+++ b/src/main/java/com/nighttrip/core/domain/touristspot/entity/TouristSpot.java
@@ -32,7 +32,7 @@ public class TouristSpot {
 
     private Double longitude;
     private Double latitude;
-    private Integer chkeCount;
+    private Integer checkCount;
     private String category;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/nighttrip/core/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/nighttrip/core/domain/user/dto/UserInfoResponse.java
@@ -1,0 +1,24 @@
+package com.nighttrip.core.domain.user.dto;
+
+import com.nighttrip.core.domain.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class UserInfoResponse {
+
+    private final Long userId;
+    private final String email;
+    private final String nickname;
+    private final String avatarImageUrl;
+    private final String role;
+    private final Integer point;
+
+    public UserInfoResponse(User user) {
+        this.userId = user.getId();
+        this.email = user.getEmail();
+        this.nickname = user.getNickname();
+        this.avatarImageUrl = user.getAvatar() != null ? user.getAvatar().getImageUrl() : null;
+        this.role = user.getRole().name();
+        this.point = user.getPoint();
+    }
+}

--- a/src/main/java/com/nighttrip/core/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/nighttrip/core/domain/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.nighttrip.core.domain.user.repository;
 
 import com.nighttrip.core.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,4 +11,7 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.avatar WHERE u.email = :email")
+    Optional<User> findByEmailWithAvatar(@Param("email") String email);
 }

--- a/src/main/java/com/nighttrip/core/global/config/SecurityConfig.java
+++ b/src/main/java/com/nighttrip/core/global/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)
                         )
-                        .defaultSuccessUrl("/api/v1/main/request", true)
+                        .defaultSuccessUrl("/api/v1/main", true)
                 );
 
         return http.build();

--- a/src/main/java/com/nighttrip/core/oauth/controller/OAuthController.java
+++ b/src/main/java/com/nighttrip/core/oauth/controller/OAuthController.java
@@ -1,6 +1,8 @@
 package com.nighttrip.core.oauth.controller;
 
 import com.nighttrip.core.global.dto.ApiResponse;
+import com.nighttrip.core.oauth.dto.LoginStatusResponse;
+import com.nighttrip.core.oauth.service.OAuthService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,14 @@ import org.springframework.web.bind.annotation.*;
 public class OAuthController {
 
     private final HttpSession httpSession;
+    private final OAuthService oAuthService;
+
+    @GetMapping("/status")
+    public ResponseEntity<ApiResponse<LoginStatusResponse>> checkLoginStatus() {
+        LoginStatusResponse response = oAuthService.getLoginStatus();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
 
     @PostMapping("/logout")
     public ResponseEntity<?> logout() {

--- a/src/main/java/com/nighttrip/core/oauth/dto/LoginStatusResponse.java
+++ b/src/main/java/com/nighttrip/core/oauth/dto/LoginStatusResponse.java
@@ -1,0 +1,12 @@
+package com.nighttrip.core.oauth.dto;
+
+import com.nighttrip.core.domain.user.dto.UserInfoResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LoginStatusResponse {
+    private final boolean isLoggedIn;
+    private final UserInfoResponse userInfo;
+}

--- a/src/main/java/com/nighttrip/core/oauth/service/OAuthService.java
+++ b/src/main/java/com/nighttrip/core/oauth/service/OAuthService.java
@@ -1,0 +1,34 @@
+package com.nighttrip.core.oauth.service;
+
+import com.nighttrip.core.domain.user.dto.UserInfoResponse;
+import com.nighttrip.core.domain.user.entity.User;
+import com.nighttrip.core.domain.user.repository.UserRepository;
+import com.nighttrip.core.oauth.dto.LoginStatusResponse;
+import com.nighttrip.core.oauth.util.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OAuthService {
+
+    private final UserRepository userRepository;
+
+    public LoginStatusResponse getLoginStatus() {
+        return SecurityUtils.findCurrentUserEmail()
+                .flatMap(userRepository::findByEmailWithAvatar)
+                .map(this::createLoggedInResponse)
+                .orElseGet(this::createLoggedOutResponse);
+    }
+
+    private LoginStatusResponse createLoggedInResponse(User user) {
+        UserInfoResponse userInfo = new UserInfoResponse(user);
+        return new LoginStatusResponse(true, userInfo);
+    }
+
+    private LoginStatusResponse createLoggedOutResponse() {
+        return new LoginStatusResponse(false, null);
+    }
+}


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사용자의 로그인 상태 및 기본 정보를 반환하는 API 엔드포인트를 구현

## 📝 요구 사항과 구현 내용
- API 엔드포인트 생성: GET /api/v1/auth/status
- OAuthService 계층 추가
- 성능 최적화: User 조회 시 Avatar 엔티티를 Fetch Join하여 N+1 쿼리 문제 해결
- DTO 설계 : LoginStatusResponse, UserInfoResponse DTO를 정의

## 🔗 연관된 이슈
- close #40 [Feat] 로그인 상태 확인 API 구현
